### PR TITLE
Updates logging helpers to no longer write to the output stream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Run GitVersion
     outputs:
-      semver: ${{ steps.gitversion.outputs.semver }}
-      preReleaseTag: ${{ steps.gitversion.outputs.preReleaseTag }}
+      semver: ${{ steps.run_gitversion.outputs.semver }}
+      major: ${{ steps.run_gitversion.outputs.major }}
+      majorMinor: ${{ steps.run_gitversion.outputs.major }}.${{ steps.run_gitversion.outputs.minor }}
+      preReleaseTag: ${{ steps.run_gitversion.outputs.preReleaseTag }}
     steps:
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: '3.1.402'
 
     - uses: actions/checkout@v2
       with:
@@ -28,11 +30,12 @@ jobs:
 
     - name: Install GitVersion
       run: |
-        dotnet tool install -g GitVersion.Tool --version 5.2.4
-        echo "::add-path::/github/home/.dotnet/tools"
+        dotnet tool install -g GitVersion.Tool --version 5.6.6
+        echo "/github/home/.dotnet/tools" >> $GITHUB_PATH
     - name: Run GitVersion
       id: run_gitversion
       run: |
-        pwsh -noprofile -c '(dotnet-gitversion | ConvertFrom-Json).psobject.properties | % { echo ("::set-output name=gitversion_{0}::{1}" -f $_.name, $_.value) }'
+        pwsh -noprofile -c 'dotnet-gitversion /diag'
+        pwsh -noprofile -c '(dotnet-gitversion | ConvertFrom-Json).psobject.properties | % { echo ("::set-output name={0}::{1}" -f $_.name, $_.value) }'
     - run: |
         echo "SemVer: ${{ steps.run_gitversion.outputs.gitversion_SemVer }}"

--- a/module/functions/Add-Mask.Tests.ps1
+++ b/module/functions/Add-Mask.Tests.ps1
@@ -4,7 +4,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe 'Add-Mask Tests' {
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::add-mask::Super Secret" }
+    Mock Write-Information { } -Verifiable -ParameterFilter { $MessageData -eq "`n::add-mask::Super Secret" }
     Add-Mask -Value "Super Secret"
 
     It 'should output the correct message' {

--- a/module/functions/Add-Mask.ps1
+++ b/module/functions/Add-Mask.ps1
@@ -14,5 +14,5 @@ function Add-Mask
         $Value
     )
     
-    Write-Output ("`n::add-mask::{0}" -f $Value)
+    Write-Information ("`n::add-mask::{0}" -f $Value) -InformationAction Continue
 }

--- a/module/functions/Add-Path.Tests.ps1
+++ b/module/functions/Add-Path.Tests.ps1
@@ -6,7 +6,6 @@ Describe 'Add-Path Tests' {
 
     $env:GITHUB_PATH = "TestDrive:/github_path.txt"
     
-    #Mock Write-Information { } -Verifiable -ParameterFilter { $InputObject -eq "`n::add-path::C:\foo\bar" }
     Add-Path -Path "C:\foo\bar"
 
     It 'should add the path to the correct file' {

--- a/module/functions/Add-Path.Tests.ps1
+++ b/module/functions/Add-Path.Tests.ps1
@@ -3,11 +3,14 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"
 
 Describe 'Add-Path Tests' {
+
+    $env:GITHUB_PATH = "TestDrive:/github_path.txt"
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::add-path::C:\foo\bar" }
+    #Mock Write-Information { } -Verifiable -ParameterFilter { $InputObject -eq "`n::add-path::C:\foo\bar" }
     Add-Path -Path "C:\foo\bar"
 
-    It 'should output the correct message' {
-        Assert-VerifiableMock
+    It 'should add the path to the correct file' {
+        $env:GITHUB_PATH | Should -Exist
+        "C:\foo\bar" | Should -BeIn (Get-Content $env:GITHUB_PATH)
     }
 }

--- a/module/functions/Add-Path.ps1
+++ b/module/functions/Add-Path.ps1
@@ -14,5 +14,7 @@ function Add-Path
         $Path
     )
     
-    Write-Output ("`n::add-path::{0}" -f $Path)
+    Add-Content -Path $env:GITHUB_PATH `
+                -Value $Path `
+                -Encoding ascii
 }

--- a/module/functions/Export-Variable.Tests.ps1
+++ b/module/functions/Export-Variable.Tests.ps1
@@ -4,10 +4,15 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe 'Export-Variable Tests' {
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::set-env name=foo::bar" }
+    $env:GITHUB_ENV = "TestDrive:/github_env.txt"
+
     Export-Variable -Name foo -Value bar
 
-    It 'should output the correct message' {
-        Assert-VerifiableMock
+    It 'should add the variable mapping to the correct file' {
+        $key,$value = (Get-Content $env:GITHUB_ENV) -split "="
+        
+        $env:GITHUB_ENV | Should -Exist
+        $key | Should -Be "foo"
+        $value | Should -Be "bar"
     }
 }

--- a/module/functions/Export-Variable.ps1
+++ b/module/functions/Export-Variable.ps1
@@ -19,5 +19,7 @@ function Export-Variable
         $Value
     )
     
-    Write-Output ("`n::set-env name={0}::{1}" -f $Name, $Value)
+    Add-Content -Path $env:GITHUB_ENV `
+                -Value ("{0}={1}" -f $Name, $Value) `
+                -Encoding ascii
 }

--- a/module/functions/Log-Debug.Tests.ps1
+++ b/module/functions/Log-Debug.Tests.ps1
@@ -4,7 +4,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe 'Log-Debug Tests' {
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::debug::Setting the foo variable..." }
+    Mock Write-Information { } -Verifiable -ParameterFilter { $MessageData -eq "`n::debug::Setting the foo variable..." }
     Log-Debug -Message "Setting the foo variable..."
 
     It 'should output the correct message' {

--- a/module/functions/Log-Debug.ps1
+++ b/module/functions/Log-Debug.ps1
@@ -14,5 +14,5 @@ function Log-Debug
         $Message
     )
     
-    Write-Output ("`n::debug::{0}" -f $Message)
+    Write-Information ("`n::debug::{0}" -f $Message) -InformationAction Continue
 }

--- a/module/functions/Log-Error.Tests.ps1
+++ b/module/functions/Log-Error.Tests.ps1
@@ -4,7 +4,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe 'Log-Error Tests' {
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::error::Missing semicolon" }
+    Mock Write-Information { } -Verifiable -ParameterFilter { $MessageData -eq "`n::error::Missing semicolon" }
     Log-Error -Message "Missing semicolon"
 
     It 'should output the correct message' {
@@ -14,7 +14,7 @@ Describe 'Log-Error Tests' {
 
 Describe 'Log-Error with file Tests' {
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::error file=foo.js,line=10,col=5::Missing semicolon" }
+    Mock Write-Information { } -Verifiable -ParameterFilter { $MessageData -eq "`n::error file=foo.js,line=10,col=5::Missing semicolon" }
     Log-Error -Message "Missing semicolon" -FileName "foo.js" -Line 10 -Column 5
 
     It 'should output the correct message' {

--- a/module/functions/Log-Error.ps1
+++ b/module/functions/Log-Error.ps1
@@ -28,8 +28,8 @@ function Log-Error
     )
     
     if ($PSCmdlet.ParameterSetName -eq "default") {
-        Write-Output ("`n::error::{0}" -f $Message)
+        Write-Information ("`n::error::{0}" -f $Message) -InformationAction Continue
     } elseif ($PSCmdlet.ParameterSetName -eq "file") {
-        Write-Output ("`n::error file={0},line={1},col={2}::{3}" -f $FileName, $Line, $Column, $Message)
+        Write-Information ("`n::error file={0},line={1},col={2}::{3}" -f $FileName, $Line, $Column, $Message) -InformationAction Continue
     }
 }

--- a/module/functions/Log-Warning.Tests.ps1
+++ b/module/functions/Log-Warning.Tests.ps1
@@ -4,7 +4,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe 'Log-Warning Tests' {
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::warning::Missing semicolon" }
+    Mock Write-Information { } -Verifiable -ParameterFilter { $MessageData -eq "`n::warning::Missing semicolon" }
     Log-Warning -Message "Missing semicolon"
 
     It 'should output the correct message' {
@@ -14,7 +14,7 @@ Describe 'Log-Warning Tests' {
 
 Describe 'Log-Warning with file Tests' {
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::warning file=foo.js,line=10,col=5::Missing semicolon" }
+    Mock Write-Information { } -Verifiable -ParameterFilter { $MessageData -eq "`n::warning file=foo.js,line=10,col=5::Missing semicolon" }
     Log-Warning -Message "Missing semicolon" -FileName "foo.js" -Line 10 -Column 5
 
     It 'should output the correct message' {

--- a/module/functions/Log-Warning.ps1
+++ b/module/functions/Log-Warning.ps1
@@ -28,8 +28,8 @@ function Log-Warning
     )
     
     if ($PSCmdlet.ParameterSetName -eq "default") {
-        Write-Output ("`n::warning::{0}" -f $Message)
+        Write-Information ("`n::warning::{0}" -f $Message) -InformationAction Continue
     } elseif ($PSCmdlet.ParameterSetName -eq "file") {
-        Write-Output ("`n::warning file={0},line={1},col={2}::{3}" -f $FileName, $Line, $Column, $Message)
+        Write-Information ("`n::warning file={0},line={1},col={2}::{3}" -f $FileName, $Line, $Column, $Message) -InformationAction Continue
     }
 }

--- a/module/functions/Set-Output.Tests.ps1
+++ b/module/functions/Set-Output.Tests.ps1
@@ -4,7 +4,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 
 Describe 'Set-Output Tests' {
     
-    Mock Write-Output { } -Verifiable -ParameterFilter { $InputObject -eq "`n::set-output name=foo::bar" }
+    Mock Write-Information { } -Verifiable -ParameterFilter { $MessageData -eq "`n::set-output name=foo::bar" }
     Set-Output -Name foo -Value bar
 
     It 'should output the correct message' {

--- a/module/functions/Set-Output.ps1
+++ b/module/functions/Set-Output.ps1
@@ -17,5 +17,5 @@ function Set-Output
         $Value
     )
     
-    Write-Output ("`n::set-output name={0}::{1}" -f $Name, $Value)
+    Write-Information ("`n::set-output name={0}::{1}" -f $Name, $Value) -InformationAction Continue
 }


### PR DESCRIPTION
Any GitHub ACtions logging was previously polluting the output stream which could cause issues with other processing happening inside the workflow.

Also updates 'Add-Path' and 'Export-Variable' to use the latest secure mechanisms.